### PR TITLE
fix: 🐛 sub-menu

### DIFF
--- a/illustrations.html
+++ b/illustrations.html
@@ -34,7 +34,7 @@
 
 	<section class="content">
 		<ul class="sous-menu">
-			<li><a href="./illustrations.html"><span class="clic-menu"></span>Prototype Conan plateau</span></a></li>
+			<li><a href="./illustrations.html"><span class="clic-menu">Prototype Conan plateau</span></a></li>
 			<li><a href="./illustrations/elevation.html">Illustration à l'encre</a></li>
 			<li><a href="./illustrations/eve.html">Ève</a></li>
 		</ul>

--- a/illustrations/eve.html
+++ b/illustrations/eve.html
@@ -36,7 +36,7 @@
 		<nav>
 			<ul class="sous-menu">
 				<li><a href="../illustrations.html"></span>Prototype Conan plateau</a></li>
-				<li><a href="./elevation.html"><span class="clic-menu">Illustration à l'encre</span></a></li>
+				<li><a href="./elevation.html">Illustration à l'encre</a></li>
 				<li><a href="./eve.html"><span class="clic-menu">Ève</span></a></li>
 			</ul>
 		</nav>


### PR DESCRIPTION
The active link should be in bold.